### PR TITLE
bumped versions: Axios (0.21.0 -> 1.10.0) & React (16.8.0 -> 19.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-07-11
+
+### Changed
+
+- Updated minimum Axios version from `>=0.21.0` to `^1.10.0` for better security and performance
+- Updated minimum React version from `>=16.8.0` to `^19.1.0` for latest features and improvements
+- Added Axios as both dependency and peerDependency for optimal user experience
+- Improved dependency management to prevent version conflicts
+
+### Fixed
+
+- Resolved potential React hook conflicts by optimizing dependency structure
+- Enhanced npm linking compatibility for local development
+
 ## [1.0.0] - 2025-07-11
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "react-api-forge",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-api-forge",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "axios": ">=0.21.0"
+        "axios": "^1.10.0"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.0.0",
@@ -19,14 +19,15 @@
         "@typescript-eslint/parser": "^8.36.0",
         "eslint": "^8.0.0",
         "jest": "^29.0.0",
+        "react": "^19.1.0",
         "rollup": "^3.0.0",
         "ts-jest": "^29.4.0",
         "tslib": "^2.0.0",
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "axios": ">=0.21.0",
-        "react": ">=16.8.0"
+        "axios": "^1.10.0",
+        "react": "^19.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -621,6 +622,16 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -1372,9 +1383,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.12.tgz",
-      "integrity": "sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==",
+      "version": "24.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
+      "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1451,16 +1462,6 @@
         "@typescript-eslint/parser": "^8.36.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -2598,6 +2599,16 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3220,9 +3231,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4824,8 +4835,8 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-forge",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A flexible and robust React hook factory for creating API hooks with consistent patterns",
   "type": "module",
   "main": "dist/index.js",
@@ -68,9 +68,12 @@
     "url": "https://github.com/xarlizard"
   },
   "license": "MIT",
+  "dependencies": {
+    "axios": "^1.10.0"
+  },
   "peerDependencies": {
-    "axios": ">=0.21.0",
-    "react": ">=16.8.0"
+    "axios": "^1.10.0",
+    "react": "^19.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.0.0",
@@ -83,9 +86,7 @@
     "rollup": "^3.0.0",
     "ts-jest": "^29.4.0",
     "tslib": "^2.0.0",
-    "typescript": "^5.0.0"
-  },
-  "dependencies": {
-    "axios": ">=0.21.0"
+    "typescript": "^5.0.0",
+    "react": "^19.1.0"
   }
 }


### PR DESCRIPTION
## [1.0.1] - 2025-07-11

### Changed

- Updated minimum Axios version from `>=0.21.0` to `^1.10.0` for better security and performance
- Updated minimum React version from `>=16.8.0` to `^19.1.0` for latest features and improvements
- Added Axios as both dependency and peerDependency for optimal user experience
- Improved dependency management to prevent version conflicts

### Fixed

- Resolved potential React hook conflicts by optimizing dependency structure
- Enhanced npm linking compatibility for local development